### PR TITLE
[-] Popup signal strength

### DIFF
--- a/wireless.lua
+++ b/wireless.lua
@@ -11,18 +11,20 @@ local function worker(args)
     local connected = false
 
     -- Settings
-    local ICON_DIR  = awful.util.getdir("config").."/net_widgets/icons/"
-    local interface = args.interface or "wlan0"
-    local timeout   = args.timeout or 5
-    local font      = args.font or beautiful.font
-        
+    local ICON_DIR     = awful.util.getdir("config").."/net_widgets/icons/"
+    local interface    = args.interface or "wlan0"
+    local timeout      = args.timeout or 5
+    local font         = args.font or beautiful.font
+    local popup_signal = args.popup_signal or false
+
     local net_icon = wibox.widget.imagebox()
     net_icon:set_image(ICON_DIR.."wireless_na.png")
     local net_text = wibox.widget.textbox()
     net_text:set_text(" N/A ")
     local net_timer = timer({ timeout = timeout })
-    local function net_update() 
-        local signal_level = tonumber(awful.util.pread("awk 'NR==3 {printf \"%3.0f\" ,($3/70)*100}' /proc/net/wireless"))
+    local signal_level = 0
+    local function net_update()
+        signal_level = tonumber(awful.util.pread("awk 'NR==3 {printf \"%3.0f\" ,($3/70)*100}' /proc/net/wireless"))
         if signal_level == nil then
             connected = false
             net_text:set_text(" N/A ")
@@ -36,58 +38,65 @@ local function worker(args)
                 net_icon:set_image(ICON_DIR.."wireless_1.png")
             elseif signal_level < 75 then
                 net_icon:set_image(ICON_DIR.."wireless_2.png")
-            else 
+            else
                 net_icon:set_image(ICON_DIR.."wireless_3.png")
             end
         end
     end
-    
+
     net_update()
     net_timer:connect_signal("timeout", net_update)
     net_timer:start()
-    
+
     widget:add(net_icon)
-    widget:add(net_text)
-    
+    -- Hide the text when we want to popup the signal instead
+    if not popup_signal then
+        widget:add(net_text)
+    end
+
     local function text_grabber()
         local msg = ""
         if connected then
             f = io.popen("iwconfig "..interface)
-           
-            line    = f:read() or ""    -- wlp1s0    IEEE 802.11abgn  ESSID:"ESSID" 
+            line    = f:read() or ""    -- wlp1s0    IEEE 802.11abgn  ESSID:"ESSID"
             essid   = string.match(line, "ESSID:\"(.+)\"") or " N/A "
             line    = f:read() or ""    -- Mode:Managed  Frequency:2.437 GHz  Access Point: aa:bb:cc:dd:ee:ff
             mac     = string.match(line, "Access Point: (.+)") or " N/A "
-            line    = f:read() or ""    -- Bit Rate=36 Mb/s   Tx-Power=15 dBm 
+            line    = f:read() or ""    -- Bit Rate=36 Mb/s   Tx-Power=15 dBm
             bitrate = string.match(line, "Bit Rate=(.+/s)") or " N/A "
-    
+
             f:close()
             f = io.popen("ifconfig "..interface)
-            
+
             line    = f:read() or ""    -- wlp1s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
             line    = f:read() or ""    -- inet 192.168.1.15  netmask 255.255.255.0  broadcast 192.168.1.255
             inet    = string.match(line, "inet (%d+%.%d+%.%d+%.%d+)") or " N/A "
-    
+
             f:close()
-            
-    
-            msg = 
+
+            signal = ""
+            if popup_signal then
+                signal = "├Strength\t"..signal_level.."\n"
+            end
+            msg =
                 "<span font_desc=\""..font.."\">"..
                 "┌["..interface.."]\n"..
                 "├ESSID:\t\t"..essid.."\n"..
                 "├IP:\t\t"..inet.."\n"..
                 "├BSSID\t\t"..mac.."\n"..
+                ""..signal..
                 "└Bit rate:\t"..bitrate.."</span>"
-    
+
+
         else
             msg = "Wireless network is disconnected"
         end
-    
+
         return msg
     end
-   
+
     local notification = nil
-    function widget:hide() 
+    function widget:hide()
         if notification ~= nil then
             naughty.destroy(notification)
             notification = nil
@@ -96,7 +105,7 @@ local function worker(args)
 
     function widget:show(t_out)
         widget:hide()
-    
+
         notification = naughty.notify({
             preset = fs_notification_preset,
             text = text_grabber(),


### PR DESCRIPTION
Option to display the signal strength in the popup instead of next to icon. Default is false.

![popup_signal](https://cloud.githubusercontent.com/assets/23966/6146605/a8eba74c-b1bc-11e4-826a-9468edf18009.png)

```lua
net_wireless = net_widgets.wireless({
    interface="wlp3s0",
    popup_signal=true
})
```