### PR TITLE
Use ip and iw instead of ipconfig and iwconfig.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,10 @@ You can change font to monospace by `font` option.
 
 Set `popup_signal=true`.
 
+#### Use `iw` and `ip` command instead `iwconfig` and `ipconfig`
+Set `command_mode="newer"`.
+
+When "newer" is set, `iw` and `ip` are used.
+When it isn't so, `iwconfig` and `ipconfig` are used.
+
 


### PR DESCRIPTION
I'd like to use iw command, when loading wireless infomation.
Therefore I wrote that.
Please pull, if you think it's good.

Thanks,

```Lua
net_wireless = net_widgets.wireless({
    interface="wlp3s0",
    command_mode="newer"
})
```