### PR TITLE
allow placing the module anywhere in lua search path

### DIFF
--- a/indicator.lua
+++ b/indicator.lua
@@ -2,6 +2,7 @@ local wibox         = require("wibox")
 local awful         = require("awful")
 local beautiful     = require("beautiful")
 local naughty       = require("naughty")
+local module_path = (...):match ("(.+/)[^/]+$") or ""
 
 local indicator = {}
 local function worker(args)
@@ -9,7 +10,7 @@ local function worker(args)
     local widget = wibox.widget.imagebox()
 
     local interfaces    = args.interfaces or {"enp2s0"}
-    local ICON_DIR      = awful.util.getdir("config").."/net_widgets/icons/"
+    local ICON_DIR      = awful.util.getdir("config").."/"..module_path.."/net_widgets/icons/"
     local timeout       = args.timeout or 5
     local font      = args.font or beautiful.font
     

--- a/init.lua
+++ b/init.lua
@@ -1,8 +1,10 @@
+local module_path = (...):match ("(.+/)[^/]+$") or ""
+
 package.loaded.net_widgets = nil
 
 local net_widgets = {
-    indicator   = require("net_widgets.indicator"),
-    wireless    = require("net_widgets.wireless")
+    indicator   = require(module_path .. "net_widgets.indicator"),
+    wireless    = require(module_path .. "net_widgets.wireless")
 }
 
 return net_widgets

--- a/wireless.lua
+++ b/wireless.lua
@@ -2,6 +2,7 @@ local wibox         = require("wibox")
 local awful         = require("awful")
 local beautiful     = require("beautiful")
 local naughty       = require("naughty")
+local module_path = (...):match ("(.+/)[^/]+$") or ""
 
 local wireless = {}
 local function worker(args)
@@ -11,7 +12,7 @@ local function worker(args)
     local connected = false
 
     -- Settings
-    local ICON_DIR     = awful.util.getdir("config").."/net_widgets/icons/"
+    local ICON_DIR     = awful.util.getdir("config").."/"..module_path.."/net_widgets/icons/"
     local interface    = args.interface or "wlan0"
     local timeout      = args.timeout or 5
     local font         = args.font or beautiful.font


### PR DESCRIPTION
I usually put widgets in a `widgets` subfolder in my awesome config dir. This PR allows this widget to work from there as well.